### PR TITLE
chore: enable hamidun plugins in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "enabledPlugins": {
+    "design-system@hamidun": true,
+    "web-publish@hamidun": true
+  },
   "hooks": {
     "PreCompact": [
       {


### PR DESCRIPTION
## Summary
- Добавляет `enabledPlugins` в `.claude/settings.json`, активируя `design-system@hamidun` и `web-publish@hamidun` — оба плагина были официально установлены (`scope: project`) через `/plugin install`, но не активировались, так как ключ `enabledPlugins` отсутствовал в конфиге проекта.

## Test plan
- [x] Проверено содержимое `~/.claude/plugins/installed_plugins.json` — оба плагина зарегистрированы для этого проекта с корректным `projectPath`
- [x] Проверено содержимое `~/.claude/plugins/known_marketplaces.json` — marketplace `hamidun` зарегистрирован официально
- [x] `.claude/settings.json` — валидный JSON, существующий блок `hooks` сохранён без изменений

🤖 Generated with [Claude Code](https://claude.com/claude-code)