### PR TITLE
Добавить skills-from-expertise в specialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Skills — переиспользуемые наборы инструкций, �
 - [alonw0/web-asset-generator](https://github.com/alonw0/web-asset-generator) — Favicon, app-иконки, OG-картинки.
 - [SawyerHood/dev-browser](https://github.com/SawyerHood/dev-browser) — Даёт агенту браузер: сам открывает страницу и проверяет свою работу глазами. Альтернатива Playwright MCP. 6.4k⭐.
 - [bitjaru/styleseed](https://github.com/bitjaru/styleseed) — Дизайн-движок: учит агента дизайнерскому вкусу — 74 правила в markdown, 7 бренд-скинов и именованная motion-система. Слэш-скиллы `/ss-*`.
+- [PolarSnowflake/skills-from-expertise](https://github.com/PolarSnowflake/skills-from-expertise) — Смысловая сторона написания скиллов: как превратить экспертизу в методологию, а не в список советов. Когда брать: есть чужой материал — лекция, книга, таблица, код — и нужен из него рабочий скилл.
 
 ### Локальные примеры
 

--- a/data/skills.json
+++ b/data/skills.json
@@ -36,7 +36,7 @@
     { "name": "alonw0/web-asset-generator", "url": "https://github.com/alonw0/web-asset-generator", "desc": "Favicon, app-иконки, OG-картинки." },
     { "name": "SawyerHood/dev-browser", "url": "https://github.com/SawyerHood/dev-browser", "desc": "Даёт агенту браузер: сам открывает страницу и проверяет свою работу глазами. Альтернатива Playwright MCP. 6.4k⭐." },
     { "name": "bitjaru/styleseed", "url": "https://github.com/bitjaru/styleseed", "desc": "Дизайн-движок: учит агента дизайнерскому вкусу — 74 правила в markdown, 7 бренд-скинов и именованная motion-система. Слэш-скиллы `/ss-*`." },
-    { "name": "PolarSnowflake/skills-from-expertise", "url": "https://github.com/PolarSnowflake/skills-from-expertise", "desc": "Смысловая сторона написания скиллов: как превратить экспертизу в методологию, а не в список советов. Русская и английская версии." }
+    { "name": "PolarSnowflake/skills-from-expertise", "url": "https://github.com/PolarSnowflake/skills-from-expertise", "desc": "Смысловая сторона написания скиллов: как превратить экспертизу в методологию, а не в список советов. Когда брать: есть чужой материал — лекция, книга, таблица, код — и нужен из него рабочий скилл." }
   ],
   "local": [
     { "name": "examples/skills/review-staged-changes/", "url": "./examples/skills/review-staged-changes/SKILL.md", "desc": "Проверка staged-изменений перед коммитом." }

--- a/data/skills.json
+++ b/data/skills.json
@@ -35,7 +35,8 @@
     { "name": "yusufkaraaslan/Skill_Seekers", "url": "https://github.com/yusufkaraaslan/Skill_Seekers", "desc": "Превращает сайт документации в Claude Skill." },
     { "name": "alonw0/web-asset-generator", "url": "https://github.com/alonw0/web-asset-generator", "desc": "Favicon, app-иконки, OG-картинки." },
     { "name": "SawyerHood/dev-browser", "url": "https://github.com/SawyerHood/dev-browser", "desc": "Даёт агенту браузер: сам открывает страницу и проверяет свою работу глазами. Альтернатива Playwright MCP. 6.4k⭐." },
-    { "name": "bitjaru/styleseed", "url": "https://github.com/bitjaru/styleseed", "desc": "Дизайн-движок: учит агента дизайнерскому вкусу — 74 правила в markdown, 7 бренд-скинов и именованная motion-система. Слэш-скиллы `/ss-*`." }
+    { "name": "bitjaru/styleseed", "url": "https://github.com/bitjaru/styleseed", "desc": "Дизайн-движок: учит агента дизайнерскому вкусу — 74 правила в markdown, 7 бренд-скинов и именованная motion-система. Слэш-скиллы `/ss-*`." },
+    { "name": "PolarSnowflake/skills-from-expertise", "url": "https://github.com/PolarSnowflake/skills-from-expertise", "desc": "Смысловая сторона написания скиллов: как превратить экспертизу в методологию, а не в список советов. Русская и английская версии." }
   ],
   "local": [
     { "name": "examples/skills/review-staged-changes/", "url": "./examples/skills/review-staged-changes/SKILL.md", "desc": "Проверка staged-изменений перед коммитом." }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -190,6 +190,7 @@ Skills — переиспользуемые наборы инструкций, �
 - [alonw0/web-asset-generator](https://github.com/alonw0/web-asset-generator) — Favicon, app-иконки, OG-картинки.
 - [SawyerHood/dev-browser](https://github.com/SawyerHood/dev-browser) — Даёт агенту браузер: сам открывает страницу и проверяет свою работу глазами. Альтернатива Playwright MCP. 6.4k⭐.
 - [bitjaru/styleseed](https://github.com/bitjaru/styleseed) — Дизайн-движок: учит агента дизайнерскому вкусу — 74 правила в markdown, 7 бренд-скинов и именованная motion-система. Слэш-скиллы `/ss-*`.
+- [PolarSnowflake/skills-from-expertise](https://github.com/PolarSnowflake/skills-from-expertise) — Смысловая сторона написания скиллов: как превратить экспертизу в методологию, а не в список советов. Когда брать: есть чужой материал — лекция, книга, таблица, код — и нужен из него рабочий скилл.
 
 ### Локальные примеры
 


### PR DESCRIPTION
## Что добавлено

- [PolarSnowflake/skills-from-expertise](https://github.com/PolarSnowflake/skills-from-expertise) — Смысловая сторона написания скиллов: как превратить экспертизу в методологию, а не в список советов. Когда брать: есть чужой материал — лекция, книга, таблица, код — и нужен из него рабочий скилл. Автор: @PolarSnowflake.

## В какой раздел

`data/skills.json` → `specialized`

## Почему полезно

Скилл помогает делать скиллы из готовых материалов: видео и транскрибов, статей и книг, таблиц и схем, переписки, кода, собственных заметок. Разбирает источник и собирает из него процедуру с критериями выбора, а не конспект. Отдельно — правовая часть: что можно брать из чужого материала, а что нет.

Русская версия — сам скилл на русском, а не только описание. В разделе таких почти нет.

## Чек-лист

- [x] Ресурс работает с актуальной версией Claude Code
- [x] Нет дубликата в списке
- [x] Ссылка публичная (GitHub / docs / статья)
- [x] Описание без маркетинговых слов

## Примечание про сгенерированные файлы

`validate-data.mjs` и `lint-data.mjs` прогнаны локально, оба зелёные.

`llms-full.txt` правила вручную: `build-readme.mjs` на Windows собирает его некорректно — обрезает с 2363 строк до 745, часть `catalog/*.md` не подхватывается (в логе пути идут с обратными слешами). Чтобы не залить обрезанный файл, восстановила оригинал и добавила только свою строку.